### PR TITLE
Fix failed to commit and rollback the connection while throw sql exception

### DIFF
--- a/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/AgentConnectionMgtDao.java
+++ b/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/AgentConnectionMgtDao.java
@@ -56,7 +56,15 @@ public class AgentConnectionMgtDao {
                 agentConnection.setNode(resultSet.getString("UM_NODE"));
                 agentConnections.add(agentConnection);
             }
+            connection.commit();
         } catch (SQLException e) {
+            try {
+                connection.rollback();
+            } catch (SQLException e1) {
+                throw new WSUserStoreException(
+                        "SQL transaction rollback connection error occurred while reading agent connection for tenant "
+                                + tenantDomain, e1);
+            }
             throw new WSUserStoreException("Error occurred while reading agent connection for tenant " + tenantDomain,
                     e);
         } finally {
@@ -84,6 +92,13 @@ public class AgentConnectionMgtDao {
             connection.commit();
             return true;
         } catch (SQLException e) {
+            try {
+                connection.rollback();
+            } catch (SQLException e1) {
+                throw new WSUserStoreException(
+                        "SQL transaction rollback connection error occurred while deleting agent connection for tenant : "
+                                + domain, e1);
+            }
             throw new WSUserStoreException("Error occurred while deleting agent connection for tenant : " + domain, e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, insertTokenPrepStmt);
@@ -112,6 +127,13 @@ public class AgentConnectionMgtDao {
             connection.commit();
             return true;
         } catch (SQLException e) {
+            try {
+                connection.rollback();
+            } catch (SQLException e1) {
+                throw new WSUserStoreException(
+                        "SQL transaction rollback connection error occurred while updating connection status for tenant "
+                                + tenantDomain, e1);
+            }
             throw new WSUserStoreException("Error occurred while updating connection status for tenant " + tenantDomain,
                     e);
         } finally {

--- a/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/AgentConnectionMgtDao.java
+++ b/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/AgentConnectionMgtDao.java
@@ -56,7 +56,7 @@ public class AgentConnectionMgtDao {
                 agentConnection.setNode(resultSet.getString("UM_NODE"));
                 agentConnections.add(agentConnection);
             }
-            connection.commit();
+            DatabaseUtil.commitTransaction(connection);
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(connection);
             throw new WSUserStoreException("Error occurred while reading agent connection for tenant " + tenantDomain,
@@ -83,7 +83,7 @@ public class AgentConnectionMgtDao {
             insertTokenPrepStmt.setString(1, domain);
             insertTokenPrepStmt.setString(2, tenantDomain);
             insertTokenPrepStmt.executeUpdate();
-            connection.commit();
+            DatabaseUtil.commitTransaction(connection);
             return true;
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(connection);
@@ -112,7 +112,7 @@ public class AgentConnectionMgtDao {
             insertTokenPrepStmt.setString(2, domain);
             insertTokenPrepStmt.setString(3, tenantDomain);
             insertTokenPrepStmt.executeUpdate();
-            connection.commit();
+            DatabaseUtil.commitTransaction(connection);
             return true;
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(connection);

--- a/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/AgentConnectionMgtDao.java
+++ b/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/AgentConnectionMgtDao.java
@@ -58,13 +58,7 @@ public class AgentConnectionMgtDao {
             }
             connection.commit();
         } catch (SQLException e) {
-            try {
-                connection.rollback();
-            } catch (SQLException e1) {
-                throw new WSUserStoreException(
-                        "SQL transaction rollback connection error occurred while reading agent connection for tenant "
-                                + tenantDomain, e1);
-            }
+            DatabaseUtil.rollbackTransaction(connection);
             throw new WSUserStoreException("Error occurred while reading agent connection for tenant " + tenantDomain,
                     e);
         } finally {
@@ -92,13 +86,7 @@ public class AgentConnectionMgtDao {
             connection.commit();
             return true;
         } catch (SQLException e) {
-            try {
-                connection.rollback();
-            } catch (SQLException e1) {
-                throw new WSUserStoreException(
-                        "SQL transaction rollback connection error occurred while deleting agent connection for tenant : "
-                                + domain, e1);
-            }
+            DatabaseUtil.rollbackTransaction(connection);
             throw new WSUserStoreException("Error occurred while deleting agent connection for tenant : " + domain, e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, insertTokenPrepStmt);
@@ -127,13 +115,7 @@ public class AgentConnectionMgtDao {
             connection.commit();
             return true;
         } catch (SQLException e) {
-            try {
-                connection.rollback();
-            } catch (SQLException e1) {
-                throw new WSUserStoreException(
-                        "SQL transaction rollback connection error occurred while updating connection status for tenant "
-                                + tenantDomain, e1);
-            }
+            DatabaseUtil.rollbackTransaction(connection);
             throw new WSUserStoreException("Error occurred while updating connection status for tenant " + tenantDomain,
                     e);
         } finally {

--- a/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/TokenMgtDao.java
+++ b/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/TokenMgtDao.java
@@ -39,10 +39,18 @@ public class TokenMgtDao {
             insertTokenPrepStmt.setString(2, domain);
             insertTokenPrepStmt.setString(3, status);
             resultSet = insertTokenPrepStmt.executeQuery();
+            connection.commit();
             if (resultSet.next()) {
                 return resultSet.getString("UM_TOKEN");
             }
         } catch (SQLException e) {
+            try {
+                connection.rollback();
+            } catch (SQLException e1) {
+                throw new WSUserStoreException(
+                        "SQL transaction rollback connection error occurred while reading agent connection for tenant "
+                                + tenantDomain, e1);
+            }
             throw new WSUserStoreException("Error occurred while reading agent connection for tenant " + tenantDomain,
                     e);
         } finally {
@@ -70,6 +78,12 @@ public class TokenMgtDao {
             connection.commit();
             return true;
         } catch (SQLException e) {
+            try {
+                connection.rollback();
+            } catch (SQLException e1) {
+                throw new WSUserStoreException(
+                        "SQL transaction rollback connection error occurred while persisting " + "access token", e1);
+            }
             throw new WSUserStoreException("Error occurred while persisting access token", e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, insertTokenPrepStmt);
@@ -97,6 +111,13 @@ public class TokenMgtDao {
             connection.commit();
             return true;
         } catch (SQLException e) {
+            try {
+                connection.rollback();
+            } catch (SQLException e1) {
+                throw new WSUserStoreException(
+                        "SQL transaction rollback connection error occurred while deactivating " + "access for domain: "
+                                + domain, e1);
+            }
             throw new WSUserStoreException("Error occurred while deactivating access for domain: " + domain, e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, insertTokenPrepStmt);
@@ -122,6 +143,13 @@ public class TokenMgtDao {
             connection.commit();
             return true;
         } catch (SQLException e) {
+            try {
+                connection.rollback();
+            } catch (SQLException e1) {
+                throw new WSUserStoreException(
+                        "SQL transaction rollback connection error occurred while updating " + "access token status to:"
+                                + status, e1);
+            }
             throw new WSUserStoreException("Error occurred while updating access token status to:" + status, e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, insertTokenPrepStmt);

--- a/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/TokenMgtDao.java
+++ b/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/TokenMgtDao.java
@@ -39,7 +39,7 @@ public class TokenMgtDao {
             insertTokenPrepStmt.setString(2, domain);
             insertTokenPrepStmt.setString(3, status);
             resultSet = insertTokenPrepStmt.executeQuery();
-            connection.commit();
+            DatabaseUtil.commitTransaction(connection);
             if (resultSet.next()) {
                 return resultSet.getString("UM_TOKEN");
             }
@@ -69,7 +69,7 @@ public class TokenMgtDao {
             insertTokenPrepStmt.setString(3, token.getTenant());
             insertTokenPrepStmt.setString(4, token.getDomain());
             insertTokenPrepStmt.executeUpdate();
-            connection.commit();
+            DatabaseUtil.commitTransaction(connection);
             return true;
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(connection);
@@ -97,7 +97,7 @@ public class TokenMgtDao {
             insertTokenPrepStmt.setString(2, tenantDomain);
             insertTokenPrepStmt.setString(3, domain);
             insertTokenPrepStmt.executeUpdate();
-            connection.commit();
+            DatabaseUtil.commitTransaction(connection);
             return true;
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(connection);
@@ -123,7 +123,7 @@ public class TokenMgtDao {
             insertTokenPrepStmt.setString(1, status);
             insertTokenPrepStmt.setString(2, accessToken);
             insertTokenPrepStmt.executeUpdate();
-            connection.commit();
+            DatabaseUtil.commitTransaction(connection);
             return true;
         } catch (SQLException e) {
             DatabaseUtil.rollbackTransaction(connection);

--- a/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/TokenMgtDao.java
+++ b/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/dao/TokenMgtDao.java
@@ -44,13 +44,7 @@ public class TokenMgtDao {
                 return resultSet.getString("UM_TOKEN");
             }
         } catch (SQLException e) {
-            try {
-                connection.rollback();
-            } catch (SQLException e1) {
-                throw new WSUserStoreException(
-                        "SQL transaction rollback connection error occurred while reading agent connection for tenant "
-                                + tenantDomain, e1);
-            }
+            DatabaseUtil.rollbackTransaction(connection);
             throw new WSUserStoreException("Error occurred while reading agent connection for tenant " + tenantDomain,
                     e);
         } finally {
@@ -78,12 +72,7 @@ public class TokenMgtDao {
             connection.commit();
             return true;
         } catch (SQLException e) {
-            try {
-                connection.rollback();
-            } catch (SQLException e1) {
-                throw new WSUserStoreException(
-                        "SQL transaction rollback connection error occurred while persisting " + "access token", e1);
-            }
+            DatabaseUtil.rollbackTransaction(connection);
             throw new WSUserStoreException("Error occurred while persisting access token", e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, insertTokenPrepStmt);
@@ -111,13 +100,7 @@ public class TokenMgtDao {
             connection.commit();
             return true;
         } catch (SQLException e) {
-            try {
-                connection.rollback();
-            } catch (SQLException e1) {
-                throw new WSUserStoreException(
-                        "SQL transaction rollback connection error occurred while deactivating " + "access for domain: "
-                                + domain, e1);
-            }
+            DatabaseUtil.rollbackTransaction(connection);
             throw new WSUserStoreException("Error occurred while deactivating access for domain: " + domain, e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, insertTokenPrepStmt);
@@ -143,13 +126,7 @@ public class TokenMgtDao {
             connection.commit();
             return true;
         } catch (SQLException e) {
-            try {
-                connection.rollback();
-            } catch (SQLException e1) {
-                throw new WSUserStoreException(
-                        "SQL transaction rollback connection error occurred while updating " + "access token status to:"
-                                + status, e1);
-            }
+            DatabaseUtil.rollbackTransaction(connection);
             throw new WSUserStoreException("Error occurred while updating access token status to:" + status, e);
         } finally {
             IdentityDatabaseUtil.closeAllConnections(connection, null, insertTokenPrepStmt);

--- a/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/util/DatabaseUtil.java
+++ b/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/util/DatabaseUtil.java
@@ -93,4 +93,21 @@ public class DatabaseUtil {
             LOGGER.error("An error occurred while rolling back transactions. ", e1);
         }
     }
+
+    /**
+     * Commit the transaction.
+     *
+     * @param dbConnection database connection.
+     * @throws SQLException SQL Exception.
+     */
+    public static void commitTransaction(Connection dbConnection) {
+
+        try {
+            if (dbConnection != null) {
+                dbConnection.commit();
+            }
+        } catch (SQLException e1) {
+            LOGGER.error("An error occurred while commit transactions. ", e1);
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/util/DatabaseUtil.java
+++ b/components/org.wso2.carbon.identity.user.store.onprem.outbound/src/main/java/org/wso2/carbon/identity/user/store/outbound/util/DatabaseUtil.java
@@ -76,4 +76,21 @@ public class DatabaseUtil {
             throw new WSUserStoreException(errMsg, e);
         }
     }
+
+    /**
+     * Revoke the transaction when catch then sql transaction errors.
+     *
+     * @param dbConnection database connection.
+     * @throws SQLException SQL Exception.
+     */
+    public static void rollbackTransaction(Connection dbConnection) {
+
+        try {
+            if (dbConnection != null) {
+                dbConnection.rollback();
+            }
+        } catch (SQLException e1) {
+            LOGGER.error("An error occurred while rolling back transactions. ", e1);
+        }
+    }
 }


### PR DESCRIPTION

## Purpose
When we use the JDBC transaction by applying connection.commit() to commit the SQL statements and make sure SQL statements within a transaction block are all executed successfully. if either one of the SQL statement within the transaction block is failed, abort and rollback everything within the transaction block.
In the identity-userstore-onprem-agent repository, there are some places use the JDBC transaction but did not properly commit and rollback the transaction.

Issue: https://github.com/wso2/product-is/issues/5478